### PR TITLE
Replace single config.json with a buffer of files

### DIFF
--- a/packages/client-app/src/fs-utils.es6
+++ b/packages/client-app/src/fs-utils.es6
@@ -1,9 +1,50 @@
 import fs from 'fs'
-import Utils from './flux/models/utils'
+import path from 'path';
 
-export function atomicWriteFileSync(filepath, content) {
-  const randomId = Utils.generateTempId()
-  const backupPath = `${filepath}.${randomId}.bak`
-  fs.writeFileSync(backupPath, content)
-  fs.renameSync(backupPath, filepath)
+function getSortedTimestampedFilesSync(filepath, basename, extension) {
+  let files = fs.readdirSync(filepath);
+  files = files.filter((file) => {
+    const hasConfig = file.indexOf(`${basename}.`) > -1;
+    const hasJSON = file.indexOf(`.${extension}`) > -1;
+    const hasExactName = file.indexOf(`${basename}.${extension}`) > -1;
+    return hasConfig && hasJSON && !hasExactName;
+  });
+
+  files = files.sort((a, b) => {
+    const aValues = a.split('.');
+    const bValues = b.split('.');
+
+    return parseInt(aValues[1], 10) - parseInt(bValues[1], 10);
+  });
+
+  return files;
+}
+
+export function atomicWriteFileSync(filepath, basename, extension, content) {
+  let fileNum = 0;
+  let newFile;
+  while (typeof newFile === "undefined" || fs.existsSync(newFile)) {
+    const milliseconds = (new Date()).getTime() * 1000 + fileNum;
+    newFile = path.join(filepath, `${basename}.${milliseconds}.${extension}`);
+    fileNum++;
+  }
+  fs.writeFileSync(newFile, content);
+
+  const files = getSortedTimestampedFilesSync(filepath, basename, extension);
+
+  while (files.length > 10) {
+    let fileToDelete = files.splice(0, 1);
+    fileToDelete = fileToDelete[0];
+    fs.unlinkSync(path.join(filepath, fileToDelete));
+  }
+}
+
+export function getMostRecentTimestampedFile(filepath, basename, extension, offset = 0) {
+  let myOffset = offset;
+  if (myOffset < 0) myOffset = 0;
+  if (myOffset > 9) myOffset = 9;
+
+  const files = getSortedTimestampedFilesSync(filepath, basename, extension);
+
+  return files[files.length - 1 - myOffset];
 }


### PR DESCRIPTION
This makes it so that we never have to rename a config.json.bak file over the current config.json file. This also reduces the chance of file writing collusion. This is to prevent corrupt config.json files

This fixes #15 