### PR TITLE
Changes the forceWrite to use this.draft instead of false [Solves issue #38]

### DIFF
--- a/packages/client-app/src/flux/models/message.es6
+++ b/packages/client-app/src/flux/models/message.es6
@@ -109,7 +109,7 @@ export default class Message extends ModelWithMetadata {
         return MessageBodyUtils.writeBody({
           msgId: this.id,
           body: val,
-          forceWrite: this.draft
+          forceWrite: this.pristine
         });
       },
       deserializeFn: function deserializeBody(val) {

--- a/packages/client-app/src/flux/models/message.es6
+++ b/packages/client-app/src/flux/models/message.es6
@@ -109,7 +109,7 @@ export default class Message extends ModelWithMetadata {
         return MessageBodyUtils.writeBody({
           msgId: this.id,
           body: val,
-          forceWrite: false,
+          forceWrite: this.draft
         });
       },
       deserializeFn: function deserializeBody(val) {

--- a/packages/client-app/src/flux/models/message.es6
+++ b/packages/client-app/src/flux/models/message.es6
@@ -109,7 +109,7 @@ export default class Message extends ModelWithMetadata {
         return MessageBodyUtils.writeBody({
           msgId: this.id,
           body: val,
-          forceWrite: this.pristine
+          forceWrite: this.draft
         });
       },
       deserializeFn: function deserializeBody(val) {


### PR DESCRIPTION
this is an excerpt from #38 from the author of this PR:

The error seems to be the client-app creating the file to save the email body when we create a new message, but not updating it at all. The file doesn't get updated because the writeBody function is called with forceWrite = false every time. I think we can change it to set forceWrite = true whenever the message is a draft. the proposed change is in commit 8e82624

As far as I tested it solves the problem and doesn't have a negative impact on performance because the file is written just 2 times (vs 1 before the change): one when we click on 'New message' and the other when we send it.