### PR TITLE
Disables signing on PRs due to Travis' security policy.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ matrix:
       INSTALL_TARGET=client
 before_install:
 - if [ ${TRAVIS_PULL_REQUEST} = "false" ]; then openssl aes-256-cbc -K $encrypted_1670798fb6bd_key -iv $encrypted_1670798fb6bd_iv
-  -in ~/build/nylas-mail-lives/nylas-mail/certs/nml.p12.enc -out ~/build/nylas-mail-lives/nylas-mail/certs/nml.p12 -d
+  -in ~/build/nylas-mail-lives/nylas-mail/certs/nml.p12.enc -out ~/build/nylas-mail-lives/nylas-mail/certs/nml.p12 -d;
   fi
 install:
 - git clone https://github.com/creationix/nvm.git /tmp/.nvm
@@ -45,7 +45,7 @@ before_script:
   ~/Library/Keychains/nml-build.keychain -T /usr/bin/codesign; security import ~/build/nylas-mail-lives/nylas-mail/certs/nml.p12
   -k ~/Library/Keychains/nml-build.keychain -P $NML_CERTIFICATE_PASSWORD -T /usr/bin/codesign;
   else
-  SIGN_BUILD=false
+  SIGN_BUILD=false;
   fi
 script:
 - npm install && npm run build-client

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,21 +28,24 @@ matrix:
     env: NODE_VERSION=6.9 CC=clang CXX=clang++ SIGN_BUILD=true DEBUG="electron-packager:*"
       INSTALL_TARGET=client
 before_install:
-- openssl aes-256-cbc -K $encrypted_1670798fb6bd_key -iv $encrypted_1670798fb6bd_iv
+- if [ ${TRAVIS_PULL_REQUEST} = "false" ]; then openssl aes-256-cbc -K $encrypted_1670798fb6bd_key -iv $encrypted_1670798fb6bd_iv
   -in ~/build/nylas-mail-lives/nylas-mail/certs/nml.p12.enc -out ~/build/nylas-mail-lives/nylas-mail/certs/nml.p12 -d
+  fi
 install:
 - git clone https://github.com/creationix/nvm.git /tmp/.nvm
 - source /tmp/.nvm/nvm.sh
 - nvm install $NODE_VERSION
 - nvm use --delete-prefix $NODE_VERSION
 before_script:
-- if [ ${TRAVIS_OS_NAME} = "osx" ]; then security delete-keychain nml-build.keychain;
+- if [ ${TRAVIS_OS_NAME} = "osx" ] && [ ${TRAVIS_PULL_REQUEST} = "false" ]; then security delete-keychain nml-build.keychain;
   security create-keychain -p travis nml-build.keychain; security default-keychain
   -s nml-build.keychain; security unlock-keychain -p travis nml-build.keychain; security
   import ~/build/nylas-mail-lives/nylas-mail/certs/AppleWWDRCA.cer -k ~/Library/Keychains/nml-build.keychain
   -T /usr/bin/codesign; security import ~/build/nylas-mail-lives/nylas-mail/certs/nml.cer -k
   ~/Library/Keychains/nml-build.keychain -T /usr/bin/codesign; security import ~/build/nylas-mail-lives/nylas-mail/certs/nml.p12
   -k ~/Library/Keychains/nml-build.keychain -P $NML_CERTIFICATE_PASSWORD -T /usr/bin/codesign;
+  else
+  SIGN_BUILD=false
   fi
 script:
 - npm install && npm run build-client


### PR DESCRIPTION
This PR resolves the issue where pull requests were failing due to missing the encrypted Travis variables.
Travis deems it insecure to allow PRs access to it's encrypted variables, see: https://docs.travis-ci.com/user/pull-requests/#Pull-Requests-and-Security-Restrictions
for the reasoning.

Travis has an environment variable that allows us to detect if a PR is being processed. If it is, we disable the codesiging that uses thee encrypted variables.

This PR relies on itself passing in Travis and on a pushed (Travis watched) branch. Both of those need to pass for this PR to be accepted.

Note to reviewers: please make sure what I am doing is sane :+1: 