### PR TITLE
Match \Seen and \Flagged system flags in case-insensitive manner

### DIFF
--- a/packages/client-sync/src/local-sync-worker/sync-tasks/fetch-messages-in-folder.imap.es6
+++ b/packages/client-sync/src/local-sync-worker/sync-tasks/fetch-messages-in-folder.imap.es6
@@ -73,8 +73,8 @@ class FetchMessagesInFolderIMAP extends SyncTask {
 
       if (!msg) continue;
 
-      const unread = !attrs.flags.includes('\\Seen');
-      const starred = attrs.flags.includes('\\Flagged');
+      const unread = !attrs.flags.some((attr) => {return attr.toUpperCase() === '\\SEEN'});
+      const starred = attrs.flags.some((attr) => {return attr.toUpperCase() === '\\FLAGGED'});
       const xGmLabels = attrs['x-gm-labels'];
       const xGmLabelsJSON = xGmLabels ? JSON.stringify(xGmLabels) : null;
 


### PR DESCRIPTION
In RFC 3501, system flags are defined as being
case-insensitive. However, Nylas currently looks for the exact strings
"\Seen" and "\Flagged". This causes compatibility issues when a server
returns \SEEN or \FLAGGED.

Fixes #61