### PR TITLE
Look for plugin assets in ~/.nylas-dev when in dev mode

### DIFF
--- a/packages/client-app/src/browser/application.es6
+++ b/packages/client-app/src/browser/application.es6
@@ -44,7 +44,7 @@ export default class Application extends EventEmitter {
     this.safeMode = safeMode;
 
     this.fileListCache = new FileListCache();
-    this.nylasProtocolHandler = new NylasProtocolHandler(this.resourcePath, this.safeMode);
+    this.nylasProtocolHandler = new NylasProtocolHandler(this.configDirPath, this.resourcePath, this.safeMode);
 
     this.databaseReader = new DatabaseReader({configDirPath, specMode});
     try {

--- a/packages/client-app/src/browser/nylas-protocol-handler.es6
+++ b/packages/client-app/src/browser/nylas-protocol-handler.es6
@@ -13,16 +13,18 @@ import path from 'path';
 //   * ~/.nylas-mail/packages
 //   * RESOURCE_PATH/node_modules
 //
+// If in dev mode, ~/.nylas-mail is replaced with ~/.nylas-dev
+//
 export default class NylasProtocolHandler {
-  constructor(resourcePath, safeMode) {
+  constructor(configDirPath, resourcePath, safeMode) {
     this.loadPaths = [];
-    this.dotNylasDirectory = path.join(app.getPath('home'), '.nylas-mail');
+    this.configDirPath = configDirPath;
 
     if (!safeMode) {
-      this.loadPaths.push(path.join(this.dotNylasDirectory, 'dev', 'packages'));
+      this.loadPaths.push(path.join(configDirPath, 'dev', 'packages'));
     }
 
-    this.loadPaths.push(path.join(this.dotNylasDirectory, 'packages'));
+    this.loadPaths.push(path.join(configDirPath, 'packages'));
     this.loadPaths.push(path.join(resourcePath, 'internal_packages'));
 
     this.registerNylasProtocol();
@@ -35,7 +37,7 @@ export default class NylasProtocolHandler {
 
       let filePath = null;
       if (relativePath.indexOf('assets/') === 0) {
-        const assetsPath = path.join(this.dotNylasDirectory, relativePath);
+        const assetsPath = path.join(this.configDirPath, relativePath);
         const assetsStats = fs.statSyncNoException(assetsPath);
         if (assetsStats.isFile && assetsStats.isFile()) {
           filePath = assetsPath;


### PR DESCRIPTION
Nylas creates a protocol handler for nylas:// on startup. It adds a
number of paths to this, including the plugins directory. However,
when in normal mode the plugins directory is under ~/.nylas-mail, and
when in dev mode the plugins directory is under ~/.nylas-dev. The
protocol handler doesn't take this into consideration, and loads the
plugin directories under ~/.nylas-mail all the time. This means plugin
assets aren't loaded correctly when in dev mode.

This change passes the config directory to the protocol handler
creation code so it uses the correct directory.