### PR TITLE
Removing block to gmail.com in IMAP configuration.

### DIFF
--- a/packages/client-app/internal_packages/onboarding/lib/page-account-settings-imap.jsx
+++ b/packages/client-app/internal_packages/onboarding/lib/page-account-settings-imap.jsx
@@ -39,10 +39,6 @@ class AccountIMAPSettingsForm extends React.Component {
         errorMessage = "Please provide a valid hostname or IP adddress.";
         errorFieldNames.push(`${type}_host`);
       }
-      if (accountInfo[`${type}_host`] === 'imap.gmail.com') {
-        errorMessage = "Please link Gmail accounts by choosing 'Google' on the account type screen.";
-        errorFieldNames.push(`${type}_host`);
-      }
       if (!Number.isInteger(accountInfo[`${type}_port`] / 1)) {
         errorMessage = "Please provide a valid port number.";
         errorFieldNames.push(`${type}_port`);


### PR DESCRIPTION
Removing block to gmail.com in IMAP configuration enable users to use gmail.com through simple IMAP configuration (which doesn't call Nylas Cloud) as mentioned in #89. It works for GMail and G Suite apps. Close #89.