### PR TITLE
Help button now points to our documentation.

### DIFF
--- a/packages/client-app/src/browser/application.es6
+++ b/packages/client-app/src/browser/application.es6
@@ -353,7 +353,7 @@ export default class Application extends EventEmitter {
     });
 
     this.on('application:view-help', () => {
-      const helpUrl = 'https://support.nylas.com/hc/en-us/categories/200419318-Help-for-N1-users';
+      const helpUrl = 'https://nylas-mail-lives.gitbooks.io/nylas-mail-docs/';
       require('electron').shell.openExternal(helpUrl);
     });
 


### PR DESCRIPTION
This points the help button to our "migrated" documentation.
I've started migrating the help documentation. It appears that Nylas pulled their docs from their site.