### PR TITLE
enable keybase plugin

### DIFF
--- a/packages/client-app/internal_packages/keybase/package.json
+++ b/packages/client-app/internal_packages/keybase/package.json
@@ -6,7 +6,7 @@
     "nylas": "*"
   },
   "isOptional": true,
-  "isHiddenOnPluginsPage": true,
+  "isHiddenOnPluginsPage": false,
 
   "title": "Encryption",
   "description": "Send and receive encrypted messages using Keybase for public key exchange.",


### PR DESCRIPTION
I enabled Keybase PGP plugin which was previously not available in UI, probably due to the fact it was made available only for Nylas Pro users. There will probably be some bugs, but the basic encryption and decryption flow is working. (https://github.com/nylas/nylas-mail/issues/3328)