### PR TITLE
Enhancements to the Quick Search

### DIFF
--- a/packages/client-app/internal_packages/thread-search/lib/search-store.es6
+++ b/packages/client-app/internal_packages/thread-search/lib/search-store.es6
@@ -126,8 +126,8 @@ class SearchStore extends NylasStore {
       this._compileResults();
     })
 
-    this._fetchThreadResults();
     this._fetchContactResults();
+    this._fetchThreadResults();
   }
 
   _fetchContactResults() {

--- a/packages/client-app/internal_packages/thread-search/lib/search-store.es6
+++ b/packages/client-app/internal_packages/thread-search/lib/search-store.es6
@@ -189,20 +189,20 @@ class SearchStore extends NylasStore {
       value: this._searchQuery,
     });
 
+    if (this._contactResults.length) {
+      this._suggestions.push({ divider: 'People' });
+      for (const contact of this._contactResults) {
+        this._suggestions.push({
+          contact: contact,
+          value: contact.email
+        });
+      }
+    }
+
     if (this._threadResults.length) {
       this._suggestions.push({divider: 'Threads'});
       for (const thread of this._threadResults) {
         this._suggestions.push({thread});
-      }
-    }
-
-    if (this._contactResults.length) {
-      this._suggestions.push({divider: 'People'});
-      for (const contact of this._contactResults) {
-        this._suggestions.push({
-          contact: contact,
-          value: contact.email,
-        });
       }
     }
 

--- a/packages/client-app/static/components/search-bar.less
+++ b/packages/client-app/static/components/search-bar.less
@@ -34,7 +34,8 @@
     top: 23px;
     z-index: 2;
     width: 100%;
-
+    overflow: scroll;
+    max-height: 640px;
     box-shadow: @standard-shadow;
 
     .item {


### PR DESCRIPTION
This PR has two enhancements:

1.  It changes the order of the results in the quick search pop-over to show contacts first, and threads later.
2.  It fixes the max height of the results pop-over and adds a scroll to allow users to scroll through the list.