### PR TITLE
Support to show ICS invite as attachments

### DIFF
--- a/packages/client-app/static/components/search-bar.less
+++ b/packages/client-app/static/components/search-bar.less
@@ -34,7 +34,7 @@
     top: 23px;
     z-index: 2;
     width: 100%;
-    overflow: scroll;
+    overflow-y: scroll;
     max-height: 50vh;
     box-shadow: @standard-shadow;
 

--- a/packages/client-sync/src/message-processor/extract-files.js
+++ b/packages/client-sync/src/message-processor/extract-files.js
@@ -26,6 +26,7 @@ function collectFilesFromStruct({db, messageValues, struct, fileIds = new Set()}
       // to ensure that there is a filename and contentId because some clients
       // use "inline" for text in the body.
       const isAttachment = /(attachment)/gi.test(disposition.type) ||
+        /(calendar)/gi.test(part.subtype) ||
         (/(inline)/gi.test(disposition.type) && filename && contentId);
 
       if (!isAttachment) continue


### PR DESCRIPTION
ICS invites are currently not displayed correctly in Nylas.  This PR adds support to extract calendar files and store them as attachments.  The attachment is called  `Event.ics`.  

First implementation for #132 