### PR TITLE
Prevent saving config.json files when not necessary

### DIFF
--- a/packages/client-app/package.json
+++ b/packages/client-app/package.json
@@ -69,6 +69,7 @@
     "mailparser": "^0.6.1",
     "mailto-parser": "^1.0.0",
     "marked": "^0.3",
+    "md5": "2.2.1",
     "mimelib": "0.2.19",
     "mkdirp": "^0.5",
     "moment": "2.12.0",

--- a/packages/client-app/src/fs-utils.es6
+++ b/packages/client-app/src/fs-utils.es6
@@ -1,6 +1,8 @@
 import fs from 'fs'
 import path from 'path';
 
+const numberOfConfigFiles = 20;
+
 function getSortedTimestampedFilesSync(filepath, basename, extension) {
   let files = fs.readdirSync(filepath);
   files = files.filter((file) => {
@@ -32,7 +34,7 @@ export function atomicWriteFileSync(filepath, basename, extension, content) {
 
   const files = getSortedTimestampedFilesSync(filepath, basename, extension);
 
-  while (files.length > 10) {
+  while (files.length > numberOfConfigFiles) {
     let fileToDelete = files.splice(0, 1);
     fileToDelete = fileToDelete[0];
     fs.unlinkSync(path.join(filepath, fileToDelete));


### PR DESCRIPTION
This attempts to fix #103 by limiting the number of times a config file needs to be updated/saved in a few ways:
- Don't save a config file if it matches completely (using md5 hash) with the currently loaded config (which was/is saved) which also prevents all of the workers saving the same file (even one it just loaded at startup)
- Don't increment the accountsVersion if the accounts haven't changed (using md5 hash) which in change prevents a save
- Increase the number of config files to 20. This is because there are 6 workers and apparently all of them can independently save config files. That means, worst case scenario, all 6 could write the same config file independently at the same time. Wit the current limit of 10 files, this would mean only 2 versions of the config file could be stored. Increasing this limit should greatly reduce the amount of corruptions per version of the file