### PR TITLE
Fixes the scroll in Search pop-over #135

### DIFF
--- a/packages/client-app/static/components/search-bar.less
+++ b/packages/client-app/static/components/search-bar.less
@@ -34,7 +34,7 @@
     top: 23px;
     z-index: 2;
     width: 100%;
-    overflow-y: scroll;
+    overflow-y: auto;
     max-height: 50vh;
     box-shadow: @standard-shadow;
 

--- a/packages/client-app/static/components/search-bar.less
+++ b/packages/client-app/static/components/search-bar.less
@@ -34,7 +34,7 @@
     top: 23px;
     z-index: 2;
     width: 100%;
-    overflow: scroll;
+    overflow-y: scroll;
     max-height: 50vh;
     box-shadow: @standard-shadow;
 


### PR DESCRIPTION
@seesemichaelj caught a UI bug where the search pop-over always had scroll bars (even if they weren't needed).  Changed `overflow: scroll` to `overflow-y:auto` to fix it.  The horizontal scroll was never needed because the content the truncated to fit the width.

Fixed #135 