### PR TITLE
Make the osx menu look like the ones in linux/windows

### DIFF
--- a/packages/client-app/menus/darwin.json
+++ b/packages/client-app/menus/darwin.json
@@ -1,119 +1,92 @@
 {
   "menu": [
-  {
-    "label": "Nylas Mail",
-    "submenu": [
-      { "label": "About Nylas Mail", "command": "application:about" },
-      { "type": "separator" },
-      { "label": "Preferences", "command": "application:open-preferences" },
-      { "label": "Change Theme...", "command": "window:launch-theme-picker" },
-      { "label": "Install Theme...", "command": "application:install-package" },
-      { "type": "separator" },
-      { "label": "Add Account...", "command": "application:add-account", "args": {"source": "Menu"}},
-      { "label": "VERSION", "enabled": false },
-      { "type": "separator" },
-      { "type": "separator" },
-      { "label": "Services", "submenu": [] },
-      { "type": "separator" },
-      { "label": "Hide Nylas Mail", "command": "application:hide" },
-      { "label": "Hide Others", "command": "application:hide-other-applications" },
-      { "label": "Show All", "command": "application:unhide-all-applications" },
-      { "type": "separator" },
-      { "label": "Quit", "command": "application:quit" }
-    ]
-  },
-  {
-    "label": "File",
-    "submenu": [
-      { "label": "New Message", "command": "application:new-message" },
-      { "type": "separator" },
-      { "label": "Close Window", "command": "window:close" },
-      { "type": "separator" },
-      { "label": "Print Current Thread", "command": "core:print-thread" }
-    ]
-  },
+    {
+      "label": "&Edit",
+      "submenu": [
+        { "label": "&Undo", "command": "core:undo" },
+        { "label": "&Redo", "command": "core:redo" },
+        { "type": "separator" },
+        { "label": "Cu&t", "command": "core:cut" },
+        { "label": "&Copy", "command": "core:copy" },
+        { "label": "&Paste", "command": "core:paste" },
+        { "label": "Paste and Match Style", "command": "core:paste-and-match-style" },
+        { "label": "Select &All", "command": "core:select-all" },
+        { "type": "separator" },
+        { "label": "Find", "submenu": [
+          { "label": "Find in Thread...", "command": "core:find-in-thread" },
+          { "label": "Find Next", "command": "core:find-in-thread-next" },
+          { "label": "Find Previous", "command": "core:find-in-thread-previous" }
+        ] }
+      ]
+    },
 
-  {
-    "label": "Edit",
-    "submenu": [
-      { "label": "Undo", "command": "core:undo" },
-      { "label": "Redo", "command": "core:redo" },
-      { "type": "separator" },
-      { "label": "Cut", "command": "core:cut" },
-      { "label": "Copy", "command": "core:copy" },
-      { "label": "Paste", "command": "core:paste" },
-      { "label": "Paste and Match Style", "command": "core:paste-and-match-style" },
-      { "label": "Select All", "command": "core:select-all" },
-      { "type": "separator" },
-      { "label": "Find", "submenu": [
-        { "label": "Find in Thread...", "command": "core:find-in-thread" },
-        { "label": "Find Next", "command": "core:find-in-thread-next" },
-        { "label": "Find Previous", "command": "core:find-in-thread-previous" }
-      ] }
-    ]
-  },
+    {
+      "label": "&View",
+      "submenu": [
+        { "type": "separator", "id": "mailbox-navigation"},
+        { "label": "Go to Inbox", "command": "navigation:go-to-inbox" },
+        { "label": "Go to Starred", "command": "navigation:go-to-starred" },
+        { "label": "Go to Sent", "command": "navigation:go-to-sent" },
+        { "label": "Go to Drafts", "command": "navigation:go-to-drafts" },
+        { "label": "Go to All mail", "command": "navigation:go-to-all" },
+        { "type": "separator" },
+        { "label": "Enter Full Screen", "command": "window:toggle-full-screen" },
+        { "label": "Exit Full Screen", "command": "window:toggle-full-screen", "visible": false }
+      ]
+    },
 
-  {
-    "label": "View",
-    "submenu": [
-      { "type": "separator", "id": "mailbox-navigation"},
-      { "label": "Go to Inbox", "command": "navigation:go-to-inbox" },
-      { "label": "Go to Starred", "command": "navigation:go-to-starred" },
-      { "label": "Go to Sent", "command": "navigation:go-to-sent" },
-      { "label": "Go to Drafts", "command": "navigation:go-to-drafts" },
-      { "label": "Go to All mail", "command": "navigation:go-to-all" },
-      { "type": "separator" },
-      { "label": "Enter Full Screen", "command": "window:toggle-full-screen" },
-      { "label": "Exit Full Screen", "command": "window:toggle-full-screen", "visible": false }
-    ]
-  },
-
-  {
-    "label": "Thread",
-    "submenu": [
-      { "label": "Reply", "command": "core:reply" },
-      { "label": "Reply All", "command": "core:reply-all" },
-      { "label": "Forward", "command": "core:forward" },
-      { "type": "separator" },
-      { "label": "Star", "command": "core:star-item" },
-      { "type": "separator", "id": "thread-actions" },
-      { "label": "Remove from view", "command": "core:remove-from-view" },
-      { "type": "separator", "id": "view-actions" }
-    ]
-  },
-
-  {
-    "label": "Developer",
-    "submenu": [
-      { "label": "Run with Debug Flags", "type": "checkbox", "command": "application:toggle-dev" },
-      { "type": "separator" },
-      { "label": "Reload", "command": "window:reload" },
-      { "label": "Toggle Developer Tools", "command": "window:toggle-dev-tools" },
-      { "label": "Toggle Component Regions", "command": "window:toggle-component-regions" },
-      { "label": "Toggle Screenshot Mode", "command": "window:toggle-screenshot-mode" },
-      { "type": "separator" },
-      { "label": "Create a Plugin...", "command": "application:create-package" },
-      { "label": "Install a Plugin...", "command": "application:install-package" },
-      { "type": "separator" },
-      { "label": "Open Detailed Logs", "command": "window:open-errorlogger-logs" }
-    ]
-  },
-  {
-    "label": "Window",
-    "submenu": [
-      { "label": "Minimize", "command": "application:minimize" },
-      { "label": "Zoom", "command": "application:zoom" },
-      { "type": "separator", "id": "window-list-separator" },
-      { "type": "separator" },
-      { "label": "Bring All to Front", "command": "application:bring-all-windows-to-front" }
-    ]
-  },
-
-  {
-    "label": "Help",
-    "submenu": [
-      { "label": "Nylas Mail Help", "command": "application:view-help" }
-    ]
-  }
+    {
+      "label": "Thread",
+      "submenu": [
+        { "label": "Reply", "command": "core:reply" },
+        { "label": "Reply All", "command": "core:reply-all" },
+        { "label": "Forward", "command": "core:forward" },
+        { "type": "separator" },
+        { "label": "Star", "command": "core:star-item" },
+        { "type": "separator", "id": "thread-actions" },
+        { "label": "Remove from view", "command": "core:remove-from-view" },
+        { "type": "separator", "id": "view-actions" }
+      ]
+    },
+    {
+      "label": "Developer",
+      "submenu": [
+        { "label": "Run with &Debug Flags", "type": "checkbox", "command": "application:toggle-dev" },
+        { "type": "separator" },
+        { "label": "&Reload", "command": "window:reload" },
+        { "label": "Toggle Developer &Tools", "command": "window:toggle-dev-tools" },
+        { "label": "Toggle Component Regions", "command": "window:toggle-component-regions" },
+        { "label": "Toggle Screenshot Mode", "command": "window:toggle-screenshot-mode" },
+        { "type": "separator" },
+        { "label": "Create a Plugin...", "command": "application:create-package" },
+        { "label": "Install a Plugin...", "command": "application:install-package" },
+        { "type": "separator" },
+        { "label": "Open Detailed Logs", "command": "window:open-errorlogger-logs" }
+      ]
+    },
+    {
+      "label": "Window",
+      "submenu": [
+        { "label": "Minimize", "command": "application:minimize" },
+        { "label": "Zoom", "command": "application:zoom" },
+        { "type": "separator", "id": "window-list-separator" }
+      ]
+    },
+    { "type": "separator" },
+    {
+      "label": "&Help...",
+      "command": "application:view-help"
+    },
+    { "type": "separator" },
+    { "label": "Preferences", "command": "application:open-preferences" },
+    { "label": "Add Account...", "command": "application:add-account", "args": {"source": "Menu"}},
+    { "label": "Change Theme...", "command": "window:launch-theme-picker" },
+    { "label": "Install Theme...", "command": "application:install-package" },
+    { "type": "separator" },
+    { "label": "VERSION", "enabled": false },
+    { "type": "separator" },
+    { "label": "Print Current Thread", "command": "core:print-thread" },
+    { "type": "separator" },
+    { "label": "E&xit", "command": "application:quit" }
   ]
 }


### PR DESCRIPTION
I guess for some reason in #112 and #111, the OSX menu got overlooked and still has the old menu; this fixes that