### PR TITLE
Nylas default theme fix

### DIFF
--- a/packages/client-app/internal_packages/thread-list/stylesheets/thread-list.less
+++ b/packages/client-app/internal_packages/thread-list/stylesheets/thread-list.less
@@ -348,6 +348,10 @@ body.platform-win32 {
   }
 }
 
+.selection-bar .absolute .inner{
+  background-image: -webkit-linear-gradient(lighten(@toolbar-background-color, 10%) 0%, lighten(@toolbar-background-color, 10%) 1.9%, lighten(@toolbar-background-color, 9%) 2%, @toolbar-background-color 100%);
+}
+
 .thread-list .list-item:hover .list-column-HoverActions .inner {
   background-image: -webkit-linear-gradient(left, fade(darken(@list-bg, 5%), 0%) 0%, darken(@list-bg, 5%) 50%, darken(@list-bg, 5%) 100%);
 }


### PR DESCRIPTION
The component which appears when selecting threads was just white in the default theme.
Changed the theme so it now fits with the rest of the top bar.

Before vs. after:
![image](https://user-images.githubusercontent.com/25297553/32117442-a70743b6-bb4e-11e7-8052-b8ca6600fa10.png)
----
![image](https://user-images.githubusercontent.com/25297553/32117502-e3b9db16-bb4e-11e7-8074-abd0b8ee1bcc.png)
