### PR TITLE
(re)Enable Mail Merge

### DIFF
--- a/packages/client-app/dot-nylas/config.json
+++ b/packages/client-app/dot-nylas/config.json
@@ -15,7 +15,6 @@
         "thread-sharing",
         "composer-markdown",
         "composer-scheduler",
-        "composer-mail-merge",
         "send-and-archive",
         "main-calendar",
         "open-tracking",

--- a/packages/client-app/internal_packages/composer-mail-merge/package.json
+++ b/packages/client-app/internal_packages/composer-mail-merge/package.json
@@ -1,24 +1,23 @@
 {
   "name": "composer-mail-merge",
-  "title":"Mail Merge",
-  "description": "Send personalized emails at scale using CSV-formatted data.",
   "main": "./lib/main",
-  "isHiddenOnPluginsPage": true,
   "version": "0.1.0",
+  "title": "Mail Merge",
+  "description": "Send personalized emails at scale using CSV-formatted data.",
+  "icon": "./icon.png",
+  "isOptional": true,
+  "supportedEnvs": ["local", "development", "staging", "production"],
   "engines": {
     "nylas": "*"
   },
-  "icon": "./icon.png",
-  "isOptional": true,
-  "supportedEnvs": ["production", "staging"],
   "windowTypes": {
     "default": true,
     "composer": true,
     "work": true,
     "thread-popout": true
   },
-  "license": "GPL-3.0",
   "dependencies": {
     "papaparse": "^4.1.2"
-  }
+  },
+  "license": "GPL-3.0"
 }


### PR DESCRIPTION
Mail merge was hard-disabled in Nylas Mail.  This commit makes it available and the user can activate/deactivate it from the Plugins page.

Fixes #73 