### PR TITLE
Fix the URL Link Parser #143

### DIFF
--- a/packages/client-app/src/regexp-utils.coffee
+++ b/packages/client-app/src/regexp-utils.coffee
@@ -113,7 +113,8 @@ RegExpUtils =
     if matchEntireString
       parts.unshift('^')
 
-    return new RegExp(parts.join(''), 'gi')
+    # return new RegExp(parts.join(''), 'gi')
+    return new RegExp(/((([A-Za-z]{3,9}:(?:\/\/))?(?:\w+:\w+@)?((?:(?:[-\w\d{1-3}]+\.)+(?:com|org|edu|uk|ca|de|jp|fr|au|us|co|ru|ch|it|nl|se|no|es|mil|ly|in|net|gov|mil|biz|info|mobi|name|aero|jobs|edu|co\.uk|ac\.uk|it|fr|tv|museum|asia|local|travel|[a-z]{2}))|((\b25[0-5]\b|\b[2][0-4][0-9]\b|\b[0-1]?[0-9]?[0-9]\b)(\.(\b25[0-5]\b|\b[2][0-4][0-9]\b|\b[0-1]?[0-9]?[0-9]\b)){3}))(?::[\d]{1,5})?(?:(?:(?:\/(?:[-\w~!$+|.,=]|%[a-f\d]{2})+)+|\/)+|\?|#)?(?:(?:\?(?:[-\w~!$+|.,*:]|%[a-f\d{2}])+=?(?:[-\w~!$+|.,*:=]|%[a-f\d]{2})*)(?:&(?:[-\w~!$+|.,*:]|%[a-f\d{2}])+=?(?:[-\w~!$+|.,*:=]|%[a-f\d]{2})*)*)*(?:#(?:[-\w~!$ |\/.,*:;=]|%[a-f\d]{2})*)?(?::d*)?|mailto:\/*(?:\w+\.|[\-;:&=\+\$.,\w]+@)[A-Za-z0-9\.\-]+|tel:)((?:[\+~%\/\.\w\-_@]*[\+~%\/\w\-_]+)?(?:(\?[\-\+=&;%@\.\w_\#]*[\#\-\+=&;%@\w_\/]+)?#?(?:['\$\&\(\)\*\+,;=\.\!\/\\\w%-]*[\/\\\w]+)?)?)?)/gi)
 
   # Test cases: https://regex101.com/r/jD5zC7/2
   # Returns the following capturing groups:

--- a/packages/client-app/src/regexp-utils.coffee
+++ b/packages/client-app/src/regexp-utils.coffee
@@ -39,7 +39,7 @@ RegExpUtils =
 
   # Test cases: https://regex101.com/r/pD7iS5/3
   urlRegex: ({matchEntireString} = {}) ->
-    commonTlds = ['com', 'org', 'edu', 'gov', 'uk', 'net', 'ca', 'de', 'jp', 'fr', 'au', 'us', 'ru', 'ch', 'it', 'nl', 'se', 'no', 'es', 'mil', 'ly']
+    commonTlds = ['com', 'org', 'edu', 'gov', 'uk', 'net', 'ca', 'de', 'jp', 'fr', 'au', 'us', 'ru', 'ch', 'it', 'nl', 'se', 'no', 'es', 'mil', 'ly', 'co', 'in', 'it', 'co\.uk', 'info', 'biz', 'ai']
 
     parts = [
       '('
@@ -61,41 +61,37 @@ RegExpUtils =
             # one of:
             '('
               # domain with any tld
-              '([a-zA-Z0-9-_]+\\.)*[a-zA-Z0-9][a-zA-Z0-9-_]+\\.[a-zA-Z]{2,11}'
+              '(?:(?:[-\\w\\d{1-3}]+\\.)+(?:' + commonTlds.join('|') + '|[a-z]{2,4}))'
 
               '|'
 
               # ip address
-              '(?:[0-9]{1,3}\\.){3}[0-9]{1,3}'
+              '((\\b25[0-5]\\b|\\b[2][0-4][0-9]\\b|\\b[0-1]?[0-9]?[0-9]\\b)(\.(\\b25[0-5]\\b|\\b[2][0-4][0-9]\\b|\\b[0-1]?[0-9]?[0-9]\\b)){3})'
             ')'
+
+            # port if specified
+            '(?::[\\d]{1,5})?'
+
+            # URL Path
+            '(?:(?:(?:\\/(?:[-\\w~!$+|.,=]|%[a-f\\d]{2})+)+|\\/)+|\\?|#)?'
+
+            # query strings
+            '(?:(?:\\?(?:[-\\w~!\\$\\+|\.,*:]|%[a-f\\d{2}])+=?(?:[-\\w~!$+|.,*:=]|%[a-f\\d]{2})*)(?:\\&(?:[-\\w~!\$\+|\.,*:]|%[a-f\\d{2}])+=?(?:[-\\w~!$+|.,*:=]|%[a-f\\d]{2})*)*)*'
+            '|'
+
+            # Anchor 
+            '(?:#(?:[-\\w~!$ |\\/\.,*:;=]|%[a-f\\d]{2})*)?'
 
             '|'
 
-            # scheme, ala https:// (optional)
-            '([A-Za-z]{3,9}:(?:\\/\\/))?'
+            # mailtos
+            'mailto:\\/*(?:\\w+\\.|[\\-;:&=\\+\\$.,\\w]+@)[A-Za-z0-9\\.\\-]+'
 
-            # username:password (optional)
-            '(?:[\\-;:&=\\+\\$,\\w]+@)?'
-
-            # one of:
-            '('
-              # domain with common tld
-              '([a-zA-Z0-9-_]+\\.)*[a-zA-Z0-9][a-zA-Z0-9-_]+\\.(?:' + commonTlds.join('|') + ')'
-
-              '|'
-
-              # ip address
-              '(?:[0-9]{1,3}\\.){3}[0-9]{1,3}'
-            ')'
           ')'
 
           # :port (optional)
           '(?::\d*)?'
 
-          '|'
-
-          # mailto:username@password.com
-          'mailto:\\/*(?:\\w+\\.|[\\-;:&=\\+\\$.,\\w]+@)[A-Za-z0-9\\.\\-]+'
         ')'
 
         # optionally followed by:
@@ -113,9 +109,8 @@ RegExpUtils =
     if matchEntireString
       parts.unshift('^')
 
-    # return new RegExp(parts.join(''), 'gi')
-    return new RegExp(/((([A-Za-z]{3,9}:(?:\/\/))?(?:\w+:\w+@)?((?:(?:[-\w\d{1-3}]+\.)+(?:com|org|edu|uk|ca|de|jp|fr|au|us|co|ru|ch|it|nl|se|no|es|mil|ly|in|net|gov|mil|biz|info|mobi|name|aero|jobs|edu|co\.uk|ac\.uk|it|fr|tv|museum|asia|local|travel|[a-z]{2}))|((\b25[0-5]\b|\b[2][0-4][0-9]\b|\b[0-1]?[0-9]?[0-9]\b)(\.(\b25[0-5]\b|\b[2][0-4][0-9]\b|\b[0-1]?[0-9]?[0-9]\b)){3}))(?::[\d]{1,5})?(?:(?:(?:\/(?:[-\w~!$+|.,=]|%[a-f\d]{2})+)+|\/)+|\?|#)?(?:(?:\?(?:[-\w~!$+|.,*:]|%[a-f\d{2}])+=?(?:[-\w~!$+|.,*:=]|%[a-f\d]{2})*)(?:&(?:[-\w~!$+|.,*:]|%[a-f\d{2}])+=?(?:[-\w~!$+|.,*:=]|%[a-f\d]{2})*)*)*(?:#(?:[-\w~!$ |\/.,*:;=]|%[a-f\d]{2})*)?(?::d*)?|mailto:\/*(?:\w+\.|[\-;:&=\+\$.,\w]+@)[A-Za-z0-9\.\-]+|tel:)((?:[\+~%\/\.\w\-_@]*[\+~%\/\w\-_]+)?(?:(\?[\-\+=&;%@\.\w_\#]*[\#\-\+=&;%@\w_\/]+)?#?(?:['\$\&\(\)\*\+,;=\.\!\/\\\w%-]*[\/\\\w]+)?)?)?)/gi)
-
+    return new RegExp(parts.join(''), 'gi')
+  
   # Test cases: https://regex101.com/r/jD5zC7/2
   # Returns the following capturing groups:
   # 1. start of the opening a tag to href="


### PR DESCRIPTION
The regular expression for the URLs (`urlRegex`) was broken and didn't handle complex URLs correctly even if they were valid.  The new regular expression checks for links, email addresses and *tel* :)

Fixes #143