### PR TITLE
Activate Mail Rules preferences

### DIFF
--- a/packages/client-app/internal_packages/preferences/lib/main.jsx
+++ b/packages/client-app/internal_packages/preferences/lib/main.jsx
@@ -7,7 +7,7 @@ import PreferencesGeneral from './tabs/preferences-general';
 import PreferencesAccounts from './tabs/preferences-accounts';
 import PreferencesAppearance from './tabs/preferences-appearance';
 import PreferencesKeymaps from './tabs/preferences-keymaps';
-// import PreferencesMailRules from './tabs/preferences-mail-rules';
+import PreferencesMailRules from './tabs/preferences-mail-rules';
 
 export function activate() {
   PreferencesUIStore.registerPreferencesTab(new PreferencesUIStore.TabItem({
@@ -34,12 +34,12 @@ export function activate() {
     component: PreferencesKeymaps,
     order: 5,
   }))
-  // PreferencesUIStore.registerPreferencesTab(new PreferencesUIStore.TabItem({
-  //   tabId: 'Mail Rules',
-  //   displayName: 'Mail Rules',
-  //   component: PreferencesMailRules,
-  //   order: 6,
-  // }))
+  PreferencesUIStore.registerPreferencesTab(new PreferencesUIStore.TabItem({
+    tabId: 'Mail Rules',
+    displayName: 'Mail Rules',
+    component: PreferencesMailRules,
+    order: 6
+  }))
 
   WorkspaceStore.defineSheet('Preferences', {}, {
     split: ['Preferences'],


### PR DESCRIPTION
Mail Rules are a good way to organize your mail box.  For reasons unknown, the Mail Rules preference was removed (disabled) from the source.  This commit activates it back!

Fixes #157