### PR TITLE
Port the permission fix for user directory

### DIFF
--- a/packages/client-app/src/browser/config-persistence-manager.es6
+++ b/packages/client-app/src/browser/config-persistence-manager.es6
@@ -41,6 +41,12 @@ export default class ConfigPersistenceManager {
       fs.copySync(templateConfigDirPath, this.configDirPath);
     }
 
+    let stat = fs.statSync(this.configDirPath);
+    let configDirPathAccessMode = (stat.mode & parseInt('777', 8)).toString(8);
+    if (configDirPathAccessMode !== '700') {
+      fs.chmodSync(this.configDirPath, '700');
+    }
+
     if (!fs.existsSync(this.configFilePath)) {
       this.writeTemplateConfigFile();
     }


### PR DESCRIPTION
Fixes the directory permissions for the user directory to a more restricitive 700.

Fixes #181
Source Foundry376/Mailspring/pull/418