### PR TITLE
Fix the _checkForDownloadedFile

### DIFF
--- a/packages/client-app/src/flux/stores/file-download-store.es6
+++ b/packages/client-app/src/flux/stores/file-download-store.es6
@@ -349,7 +349,7 @@ class FileDownloadStore extends NylasStore {
   _checkForDownloadedFile(file) {
     return fs.statAsync(this.pathForFile(file))
     .then((stats) => {
-      return Promise.resolve(stats.size >= file.size);
+      return Promise.resolve(stats.size > 0 && stats.size <= file.size);
     })
     .catch(() => {
       return Promise.resolve(false);


### PR DESCRIPTION
Since the size of the physical file and the size from the header are always different, with the physical file being smaller in size in ~all cases, this change fixes the issue of redownloads.

With this change, once the file is downloaded, NML would not re-download the file.

Fixes #189