### PR TITLE
Add an option to enable reverse name parsing

### DIFF
--- a/packages/client-app/src/config-schema.es6
+++ b/packages/client-app/src/config-schema.es6
@@ -99,6 +99,11 @@ export default {
             'default': false,
             'title': "Display conversations in descending chronological order",
           },
+          lastNameFirstNameParsing: {
+            'type': 'boolean',
+            'default': true,
+            'title': "Automatically parse names that are in the 'Last Name, First Name' format"
+          },
         },
       },
       composing: {

--- a/packages/client-app/src/flux/models/contact.es6
+++ b/packages/client-app/src/flux/models/contact.es6
@@ -301,6 +301,12 @@ export default class Contact extends Model {
   }
 
   _parseReverseNames(name) {
+    // If the user doesn't want to parse Reverse Names, simply return an empty array
+    // Fixed https://github.com/nylas-mail-lives/nylas-mail/issues/179
+    if( !NylasEnv.config.get('core.reading.lastNameFirstNameParsing') ) {
+      return [];
+    }
+
     const parts = [];
     const [lastName, remainder] = name.split(', ');
     if (remainder) {


### PR DESCRIPTION
This PR adds a preference option for to enable/disable reverse name parsing.  The default is set to `true`.  If the user disables (changes to `false`) this from Preferences > General > Reading, NML wouldn’t attempt reverse name parsing.

Fixes #179 